### PR TITLE
Make POST requests use JSON instead of form

### DIFF
--- a/lib/alpaca_proxy/api.ex
+++ b/lib/alpaca_proxy/api.ex
@@ -28,7 +28,7 @@ defmodule AlpacaProxy.API do
     async_fetch!(
       build_url(config, conn),
       conn.method,
-      Map.to_list(conn.body_params),
+      conn.body,
       headers
     )
   end
@@ -40,9 +40,9 @@ defmodule AlpacaProxy.API do
     HTTPoison.get!(url, headers, opts)
   end
 
-  defp async_fetch!(url, "POST", body_params, headers) do
+  defp async_fetch!(url, "POST", body, headers) do
     opts = [recv_timeout: :infinity, stream_to: self(), timeout: :infinity]
-    HTTPoison.post!(url, {:form, body_params}, headers, opts)
+    HTTPoison.post!(url, Jason.encode!(body), headers, opts)
   end
 
   defp add_alpaca_authorization(req_headers, key, secret) do

--- a/lib/alpaca_proxy/api.ex
+++ b/lib/alpaca_proxy/api.ex
@@ -28,14 +28,14 @@ defmodule AlpacaProxy.API do
     async_fetch!(
       build_url(config, conn),
       conn.method,
-      conn.body,
+      conn.body_params,
       headers
     )
   end
 
   @spec async_fetch!(String.t(), method :: String.t(), body_params(), headers()) ::
           AsyncResponse.t()
-  defp async_fetch!(url, "GET", [], headers) do
+  defp async_fetch!(url, "GET", %{}, headers) do
     opts = [recv_timeout: :infinity, stream_to: self(), timeout: :infinity]
     HTTPoison.get!(url, headers, opts)
   end

--- a/test/alpaca_proxy_web/controllers/v1_test.exs
+++ b/test/alpaca_proxy_web/controllers/v1_test.exs
@@ -192,14 +192,14 @@ defmodule AlpacaProxyWeb.V1Test do
   defp execute_request(method, path, base_url, authorization) do
     opts = [recv_timeout: :infinity, stream_to: self()]
     url = Path.join(base_url, path)
-    headers = [{"authorization", authorization}]
+    headers = [{"authorization", authorization}, {"content-type", "application/json"}]
 
     case method do
       "DELETE" -> HTTPoison.delete!(url, headers, opts)
       "GET" -> HTTPoison.get!(url, headers, opts)
-      "PATCH" -> HTTPoison.patch!(url, {:form, []}, headers, opts)
-      "POST" -> HTTPoison.post!(url, {:form, []}, headers, opts)
-      "PUT" -> HTTPoison.put!(url, {:form, []}, headers, opts)
+      "PATCH" -> HTTPoison.patch!(url, "", headers, opts)
+      "POST" -> HTTPoison.post!(url, "", headers, opts)
+      "PUT" -> HTTPoison.put!(url, "", headers, opts)
     end
   end
 


### PR DESCRIPTION
The journal POST requests where failing due to Alpaca expecting a JSON binary not form data. This address that